### PR TITLE
Fix bug in Archive page: for each post show only first paragraph

### DIFF
--- a/_includes/posts/archive.html
+++ b/_includes/posts/archive.html
@@ -4,7 +4,7 @@
     <li value="{{ reverse_index }}">
         <h2><a href="{{ post.url }}">{{ post.title }} {{ post_index }}</a></h2>
         <p class="post-date">{{ post.date | date: "%B %e, %Y" }}</p>
-        {{ post | only_first_p }}
+        {{ post.excerpt }}
     </li>
     {% endfor %}    
 </ol>


### PR DESCRIPTION
Found "bug" in template archive.html.
You can see it here: http://mermaidy.github.io/archive/

It seems to me that 

``` html
{{ post | only_first_p }} 
```

don't work properly anymore. I changed it to 

``` html
{{ post.excerpt }}
```

so it will show only first paragraph of post.
